### PR TITLE
Handle RedisJSON WRONGTYPE

### DIFF
--- a/src/redis.ts
+++ b/src/redis.ts
@@ -38,7 +38,10 @@ async function detectJsonSupport(clientInstance: RedisClientType): Promise<boole
     hasJsonSupport = true;
   } catch (err: any) {
     const message = String(err?.message || err);
-    if (message.toLowerCase().includes("unknown command")) {
+    const normalized = message.toLowerCase();
+    if (normalized.includes("unknown command")) {
+      hasJsonSupport = false;
+    } else if (normalized.includes("wrongtype")) {
       hasJsonSupport = false;
     } else {
       throw err;


### PR DESCRIPTION
## Summary
- treat WRONGTYPE as a recoverable case in RedisJSON detection
- fall back to legacy string storage when a legacy state key exists

## Testing
- not run (not requested)