### PR TITLE
Expose public prompts endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Because access is enforced at the API layer:
 
 ### Read
 - `GET /health`
+- `GET /prompt/{name}` (public prompt files, e.g. `prompt/pm_system_prompt`)
 - `GET /v1/requirements`
 - `GET /v1/requirements/{id}`
 
@@ -174,6 +175,86 @@ Because access is enforced at the API layer:
 No patch semantics.
 No diff ingestion.
 No repo mutation.
+
+---
+
+## Quickstart
+
+Base URL assumes `http://localhost:3000`.
+
+Public endpoints (no headers required):
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/prompt/pm_system_prompt
+```
+
+Get all requirements (headers required):
+```bash
+curl http://localhost:3000/v1/requirements \\
+  -H "X-Agent-Role: pm" \\
+  -H "X-Agent-Id: pm-1"
+```
+
+Get one requirement:
+```bash
+curl http://localhost:3000/v1/requirements/REQ-1 \\
+  -H "X-Agent-Role: pm" \\
+  -H "X-Agent-Id: pm-1"
+```
+
+Bulk create requirements (PM only):
+```bash
+curl -X POST http://localhost:3000/v1/requirements/bulk \\
+  -H "Content-Type: application/json" \\
+  -H "X-Agent-Role: pm" \\
+  -H "X-Agent-Id: pm-1" \\
+  -d '{\"requirements\":[{\"req_id\":\"REQ-1\",\"title\":\"Core service\",\"priority\":{\"tier\":\"p0\",\"rank\":1}}]}'
+```
+
+Update overall status (PM only):
+```bash
+curl -X PUT http://localhost:3000/v1/requirements/REQ-1/status \\
+  -H "Content-Type: application/json" \\
+  -H "X-Agent-Role: pm" \\
+  -H "X-Agent-Id: pm-1" \\
+  -d '{\"overall_status\":\"in_progress\"}'
+```
+
+Update PM section (PM only):
+```bash
+curl -X PUT http://localhost:3000/v1/requirements/REQ-1/pm \\
+  -H "Content-Type: application/json" \\
+  -H "X-Agent-Role: pm" \\
+  -H "X-Agent-Id: pm-1" \\
+  -d '{\"section\":{\"status\":\"in_progress\",\"direction\":\"...\",\"feedback\":\"\",\"decision\":\"pending\"},\"priority\":{\"tier\":\"p0\",\"rank\":1}}'
+```
+
+Update architecture section (Architect only):
+```bash
+curl -X PUT http://localhost:3000/v1/requirements/REQ-1/architecture \\
+  -H "Content-Type: application/json" \\
+  -H "X-Agent-Role: architect" \\
+  -H "X-Agent-Id: architect-1" \\
+  -d '{\"section\":{\"status\":\"in_progress\",\"design_spec\":\"...\"}}'
+```
+
+Update engineering section (Coder only):
+```bash
+curl -X PUT http://localhost:3000/v1/requirements/REQ-1/engineering \\
+  -H "Content-Type: application/json" \\
+  -H "X-Agent-Role: coder" \\
+  -H "X-Agent-Id: coder-1" \\
+  -d '{\"section\":{\"status\":\"in_progress\",\"implementation_notes\":\"...\",\"pr\":null}}'
+```
+
+Update QA section (Tester only):
+```bash
+curl -X PUT http://localhost:3000/v1/requirements/REQ-1/qa \\
+  -H "Content-Type: application/json" \\
+  -H "X-Agent-Role: tester" \\
+  -H "X-Agent-Id: tester-1" \\
+  -d '{\"section\":{\"status\":\"in_progress\",\"test_plan\":\"...\",\"test_cases\":[],\"test_results\":{\"status\":\"\",\"notes\":\"\"}}}'
+```
 
 ---
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,15 +1,35 @@
 import express from "express";
+import path from "path";
+import { readFile } from "fs/promises";
 import requirementsRouter from "./routes/requirements.js";
 import { requireIdentity } from "./middleware/auth.js";
 
 const app = express();
+const promptsDir = path.join(process.cwd(), "prompts");
 
 app.use(express.json({ limit: "1mb" }));
 
-app.use(requireIdentity);
 app.get("/health", (_req, res) => {
   res.status(200).json({ ok: true });
 });
+app.get("/prompt/:name", async (req, res) => {
+  const name = String(req.params.name || "").trim();
+  if (!/^[a-z0-9_-]+$/i.test(name)) {
+    return res.status(400).json({ error: "invalid_prompt_name" });
+  }
+
+  const filePath = path.join(promptsDir, `${name}.txt`);
+  try {
+    const contents = await readFile(filePath, "utf-8");
+    return res.status(200).type("text/plain").send(contents);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return res.status(404).json({ error: "prompt_not_found" });
+    }
+    return res.status(500).json({ error: "prompt_read_failed" });
+  }
+});
+app.use(requireIdentity);
 app.use(requirementsRouter);
 
 app.use((req, res) => {


### PR DESCRIPTION
## Summary
- make /prompt/{name} public and document it
- add Quickstart section with curl examples for all endpoints

## Testing
- not run (not requested)