### PR TITLE
Store requirements as per-key Redis records

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Everything else (code, diffs, history) lives in Git.
 
 ## High-Level Architecture
 
-- **Single Redis JSON document** (`state`)
+- **Per-REQ Redis keys** (each requirement stored at `REQ-n`)
+- **Index sets and sorted sets** for listing and priority ordering
+- **Audit stream** for change history
 - **Single project**
 - **Unlimited requirements**
 - **JSON-only storage**

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -98,17 +98,18 @@ This requirement establishes the runnable service and foundational structure upo
 Priority: p0 / 2
 
 ### Description
-Implement a single canonical JSON document in Redis to store all orchestrator memory for the project.
+Implement canonical Redis storage for orchestrator memory using per-requirement keys and supporting indexes.
 
-This document must be treated as the authoritative shared memory across all agents.
+This storage must be treated as the authoritative shared memory across all agents.
 
 ### Acceptance Criteria
-- Entire project state is stored under a single Redis key
-- State is JSON-serializable and human-readable
-- State includes `schema_version`, `updated_at`, and `requirements` map
-- Each requirement includes per-section status fields and `overall_status`
-- State is loaded and written atomically per request
-- No partial or fragmented state storage
+- Each requirement is stored under its own Redis key (`REQ-n`)
+- Requirement values are JSON-serializable and human-readable
+- A set named `requirements` contains all requirement key names
+- A sorted set named `priority` stores requirement key names with score = tier number + rank
+- A set exists for each overall status value and contains matching requirement keys
+- All requirement changes are logged to a Redis stream (audit log)
+- Writes update requirement data and indexes atomically per request
 
 ### Out of Scope
 - Storing diffs, code, or large artifacts

--- a/src/redis.test.ts
+++ b/src/redis.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-describe("getState", () => {
-  it("initializes empty state when Redis has no value", async () => {
+describe("requirements storage", () => {
+  it("returns empty map when no requirements are stored", async () => {
     vi.resetModules();
 
     const mockClient = {
@@ -9,65 +9,16 @@ describe("getState", () => {
       on: vi.fn(),
       sendCommand: vi.fn().mockRejectedValue(new Error("ERR unknown command")),
       get: vi.fn().mockResolvedValue(null),
-      set: vi.fn().mockResolvedValue("OK")
+      sMembers: vi.fn().mockResolvedValue([])
     };
 
     vi.doMock("redis", () => ({
       createClient: vi.fn(() => mockClient)
     }));
 
-    const { getState } = await import("./redis.js");
-    const state = await getState();
+    const { listRequirements } = await import("./redis.js");
+    const requirements = await listRequirements();
 
-    expect(state.schema_version).toBe("1.0");
-    expect(state.requirements).toEqual({});
-    expect(typeof state.updated_at).toBe("string");
-  });
-
-  it("normalizes legacy requirement shapes from Redis", async () => {
-    vi.resetModules();
-
-    const legacyState = {
-      schema_version: "1.0",
-      updated_at: "2025-01-01T00:00:00Z",
-      requirements: {
-        "REQ-1": {
-          id: "REQ-1",
-          title: "Legacy requirement",
-          priority: { tier: "p0", rank: 1 },
-          status: "done",
-          pm: { status: "complete", direction: "dir", feedback: "", decision: "approved" },
-          architecture: { status: "complete", design_spec: "spec" },
-          engineering: { status: "complete", implementation_notes: "notes", pr: null },
-          qa: {
-            status: "complete",
-            test_plan: "plan",
-            test_cases: [],
-            test_results: { status: "pass", notes: "" }
-          }
-        }
-      }
-    };
-
-    const mockClient = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      on: vi.fn(),
-      sendCommand: vi.fn().mockRejectedValue(new Error("ERR unknown command")),
-      get: vi.fn().mockResolvedValue(JSON.stringify(legacyState)),
-      set: vi.fn().mockResolvedValue("OK")
-    };
-
-    vi.doMock("redis", () => ({
-      createClient: vi.fn(() => mockClient)
-    }));
-
-    const { getState } = await import("./redis.js");
-    const state = await getState();
-
-    const requirement = state.requirements["REQ-1"];
-    expect(requirement.req_id).toBe("REQ-1");
-    expect(requirement.overall_status).toBe("completed");
-    expect(requirement.sections.pm.direction).toBe("dir");
-    expect(requirement.sections.architect.design_spec).toBe("spec");
+    expect(requirements).toEqual({});
   });
 });

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -1,20 +1,28 @@
 import { createClient, RedisClientType } from "redis";
-import { Requirement, State } from "./types/state.js";
+import { Requirement, Role } from "./types/state.js";
 
 const redisUrl = process.env.REDIS_URL || "redis://localhost:6379";
+
+const REQUIREMENTS_SET = "requirements";
+const PRIORITY_ZSET = "priority";
+const AUDIT_STREAM = "audit_log";
+const STATUS_SETS = ["not_started", "in_progress", "blocked", "in_review", "completed"] as const;
 
 let client: RedisClientType | null = null;
 let hasJsonSupport: boolean | null = null;
 
-function defaultState(): State {
-  return {
-    schema_version: "1.0",
-    updated_at: new Date().toISOString(),
-    requirements: {}
-  };
+export interface AuditActor {
+  role: Role;
+  id: string;
 }
 
-function mapLegacyStatus(status: string | undefined): Requirement["overall_status"] {
+function priorityScore(priority: Requirement["priority"]): number {
+  const tierMap: Record<string, number> = { p0: 0, p1: 1, p2: 2 };
+  const tierValue = tierMap[priority.tier] ?? 0;
+  return tierValue + priority.rank;
+}
+
+function normalizeOverallStatus(status?: string): Requirement["overall_status"] {
   switch (status) {
     case "ready_for_pm_review":
       return "in_review";
@@ -23,57 +31,51 @@ function mapLegacyStatus(status: string | undefined): Requirement["overall_statu
     case "blocked":
       return "blocked";
     case "open":
-    default:
       return "not_started";
+    default:
+      return (status as Requirement["overall_status"]) ?? "not_started";
   }
 }
 
 function normalizeRequirement(id: string, requirement: any): Requirement {
-  const reqId = requirement.req_id ?? requirement.id ?? id;
-  const title = requirement.title ?? "";
-  const priority = requirement.priority ?? { tier: "", rank: 0 };
-  const overallStatus =
-    requirement.overall_status ?? mapLegacyStatus(requirement.status ?? requirement.overallStatus);
-
-  if (requirement.sections) {
+  if (requirement?.sections) {
     return {
-      req_id: reqId,
-      title,
-      priority,
-      overall_status: overallStatus,
+      req_id: requirement.req_id ?? requirement.id ?? id,
+      title: requirement.title ?? "",
+      priority: requirement.priority ?? { tier: "", rank: 0 },
+      overall_status: normalizeOverallStatus(requirement.overall_status),
       sections: requirement.sections
-    } as Requirement;
+    };
   }
 
   return {
-    req_id: reqId,
-    title,
-    priority,
-    overall_status: overallStatus,
+    req_id: requirement?.req_id ?? requirement?.id ?? id,
+    title: requirement?.title ?? "",
+    priority: requirement?.priority ?? { tier: "", rank: 0 },
+    overall_status: normalizeOverallStatus(requirement?.status ?? requirement?.overall_status),
     sections: {
-      pm: requirement.pm ?? { status: "unaddressed", direction: "", feedback: "", decision: "pending" },
-      architect: requirement.architecture ?? { status: "unaddressed", design_spec: "" },
-      coder: requirement.engineering ?? { status: "unaddressed", implementation_notes: "", pr: null },
-      tester: requirement.qa ?? {
+      pm: requirement?.pm ?? {
+        status: "unaddressed",
+        direction: "",
+        feedback: "",
+        decision: "pending"
+      },
+      architect: requirement?.architecture ?? {
+        status: "unaddressed",
+        design_spec: ""
+      },
+      coder: requirement?.engineering ?? {
+        status: "unaddressed",
+        implementation_notes: "",
+        pr: null
+      },
+      tester: requirement?.qa ?? {
         status: "unaddressed",
         test_plan: "",
         test_cases: [],
         test_results: { status: "", notes: "" }
       }
     }
-  };
-}
-
-function normalizeState(state: State): State {
-  const normalizedRequirements: Record<string, Requirement> = {};
-  for (const [key, value] of Object.entries(state.requirements ?? {})) {
-    normalizedRequirements[key] = normalizeRequirement(key, value);
-  }
-
-  return {
-    schema_version: "1.0",
-    updated_at: state.updated_at ?? new Date().toISOString(),
-    requirements: normalizedRequirements
   };
 }
 
@@ -97,14 +99,11 @@ async function detectJsonSupport(clientInstance: RedisClientType): Promise<boole
   }
 
   try {
-    await clientInstance.sendCommand(["JSON.GET", "state"]);
+    await clientInstance.sendCommand(["JSON.GET", "__json_probe__"]);
     hasJsonSupport = true;
   } catch (err: any) {
-    const message = String(err?.message || err);
-    const normalized = message.toLowerCase();
-    if (normalized.includes("unknown command")) {
-      hasJsonSupport = false;
-    } else if (normalized.includes("wrongtype")) {
+    const message = String(err?.message || err).toLowerCase();
+    if (message.includes("unknown command")) {
       hasJsonSupport = false;
     } else {
       throw err;
@@ -114,46 +113,133 @@ async function detectJsonSupport(clientInstance: RedisClientType): Promise<boole
   return hasJsonSupport;
 }
 
-export async function getState(): Promise<State> {
-  const redis = await getRedisClient();
-  const useJson = await detectJsonSupport(redis);
-
-  let raw: string | null = null;
-
+async function readJson(clientInstance: RedisClientType, key: string): Promise<string | null> {
+  const useJson = await detectJsonSupport(clientInstance);
   if (useJson) {
-    const jsonResult = (await redis.sendCommand(["JSON.GET", "state"])) as string | null;
-    raw = jsonResult ?? null;
+    const jsonResult = (await clientInstance.sendCommand(["JSON.GET", key])) as string | null;
+    return jsonResult ?? null;
+  }
+  return clientInstance.get(key);
+}
+
+async function writeJson(clientInstance: RedisClientType, key: string, payload: string) {
+  const useJson = await detectJsonSupport(clientInstance);
+  if (useJson) {
+    await clientInstance.sendCommand(["JSON.SET", key, "$", payload]);
   } else {
-    raw = await redis.get("state");
-  }
-
-  if (!raw) {
-    return defaultState();
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as State;
-    return normalizeState(parsed);
-  } catch {
-    return defaultState();
+    await clientInstance.set(key, payload);
   }
 }
 
-export async function setState(state: State): Promise<void> {
+async function migrateLegacyStateIfPresent(redis: RedisClientType) {
+  const existingIds = await redis.sMembers(REQUIREMENTS_SET);
+  if (existingIds.length > 0) {
+    return;
+  }
+
+  const raw = await readJson(redis, "state");
+  if (!raw) {
+    return;
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+
+  const legacyRequirements = parsed?.requirements ?? {};
+  const entries = Object.entries(legacyRequirements);
+  if (entries.length === 0) {
+    return;
+  }
+
+  for (const [key, value] of entries) {
+    const normalized = normalizeRequirement(key, value);
+    await saveRequirement(normalized, { role: "system", id: "migration" }, "migrate", null);
+  }
+}
+
+export async function getRequirement(reqId: string): Promise<Requirement | null> {
   const redis = await getRedisClient();
+  await migrateLegacyStateIfPresent(redis);
+
+  const raw = await readJson(redis, reqId);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return normalizeRequirement(reqId, parsed);
+  } catch {
+    return null;
+  }
+}
+
+export async function listRequirements(): Promise<Record<string, Requirement>> {
+  const redis = await getRedisClient();
+  await migrateLegacyStateIfPresent(redis);
+
+  const ids = await redis.sMembers(REQUIREMENTS_SET);
+  if (ids.length === 0) {
+    return {};
+  }
+
+  const requirements: Record<string, Requirement> = {};
+  for (const id of ids) {
+    const req = await getRequirement(id);
+    if (req) {
+      requirements[id] = req;
+    }
+  }
+  return requirements;
+}
+
+export async function saveRequirement(
+  requirement: Requirement,
+  actor: AuditActor,
+  action: string,
+  previous: Requirement | null
+): Promise<void> {
+  const redis = await getRedisClient();
+  const payload = JSON.stringify(requirement);
+  const score = priorityScore(requirement.priority);
+
+  const multi = redis.multi();
   const useJson = await detectJsonSupport(redis);
 
-  const normalized: State = {
-    ...state,
-    schema_version: "1.0",
-    updated_at: new Date().toISOString()
-  };
-
-  const payload = JSON.stringify(normalized);
-
   if (useJson) {
-    await redis.sendCommand(["JSON.SET", "state", "$", payload]);
+    multi.sendCommand(["JSON.SET", requirement.req_id, "$", payload]);
   } else {
-    await redis.set("state", payload);
+    multi.set(requirement.req_id, payload);
   }
+
+  multi.sAdd(REQUIREMENTS_SET, requirement.req_id);
+  multi.zAdd(PRIORITY_ZSET, [{ score, value: requirement.req_id }]);
+
+  for (const status of STATUS_SETS) {
+    if (status !== requirement.overall_status) {
+      multi.sRem(status, requirement.req_id);
+    }
+  }
+  multi.sAdd(requirement.overall_status, requirement.req_id);
+
+  const details = JSON.stringify({
+    overall_status: requirement.overall_status,
+    priority: requirement.priority
+  });
+
+  multi.xAdd(AUDIT_STREAM, "*", {
+    ts: new Date().toISOString(),
+    actor_role: actor.role,
+    actor_id: actor.id,
+    action,
+    req_id: requirement.req_id,
+    outcome: "success",
+    details
+  });
+
+  await multi.exec();
 }


### PR DESCRIPTION
## Summary
- store each REQ under its own Redis key and maintain indexes (requirements set, status sets, priority zset)
- add audit stream logging for writes
- refactor routes/tests to use new storage helpers and update docs

## Testing
- npm test