### PR TITLE
Tighten role-scoped PATCHes, evidence scoping, and validations

### DIFF
--- a/PR3_REVIEW.md
+++ b/PR3_REVIEW.md
@@ -1,0 +1,139 @@
+# PR3 Review Notes
+
+## Summary of externally observable behavior
+- Adds role-scoped deliverables patch endpoints:
+  - `PATCH /v1/slices/{slice_id}/design` (architect-only)
+  - `PATCH /v1/slices/{slice_id}/implementation` (coder-only)
+  - `PATCH /v1/slices/{slice_id}/tests` (tester-only)
+- Requires `X-Agent-Role` and `X-Agent-Id` headers (401 on missing/invalid).
+- Returns 401 for wrong role per endpoint.
+- Returns 404 when a slice is missing.
+- Enforces strict validation (unknown fields rejected with 400).
+- Enforces non-empty strings where applicable.
+- Rejects `status` in role PATCH payloads with `400` (status is PM-only).
+- Enforces evidence schema (`type` in `file|command|test|pr`, `ref` non-empty, `result` optional `pass|fail|null`).
+- Appends evidence to role-scoped deliverables evidence arrays with author metadata.
+- Updates only the relevant deliverables subtree (other role deliverables preserved).
+
+## Role PATCH payload allowlists
+- `PATCH /v1/slices/{slice_id}/design`: `{ design_spec, evidence }`
+- `PATCH /v1/slices/{slice_id}/implementation`: `{ implementation_notes, pr, evidence }`
+- `PATCH /v1/slices/{slice_id}/tests`: `{ test_plan, test_results, evidence }`
+
+Note: `test_results.status` is a separate field from `evidence.result`. Both may use `pass|fail`, but `test_results.status` is required within `test_results` when provided, while `evidence.result` is optional and may also be `null`.
+
+## Request/response examples
+
+### PATCH /v1/slices/{slice_id}/design
+Request:
+```json
+{
+  "design_spec": "Updated architecture notes",
+  "evidence": [{ "type": "file", "ref": "docs/design.md" }]
+}
+```
+
+Response (200):
+```json
+{
+  "slice_id": "SLICE-1",
+  "req_id": "REQ-1",
+  "title": "Initial slice",
+  "owner_role": "architect",
+  "status": "not_started",
+  "deliverables": {
+    "architect": {
+      "design_spec": "Updated architecture notes",
+      "evidence": [
+        {
+          "type": "file",
+          "ref": "docs/design.md",
+          "author": { "role": "architect", "id": "agent-3" }
+        }
+      ]
+    },
+    "coder": { "implementation_notes": null, "pr": null, "evidence": [] },
+    "tester": { "test_plan": null, "test_results": null, "evidence": [] }
+  }
+}
+```
+
+### PATCH /v1/slices/{slice_id}/implementation
+Request:
+```json
+{
+  "implementation_notes": "Implemented parser changes",
+  "pr": "https://github.com/org/repo/pull/123"
+}
+```
+
+Response (200):
+```json
+{
+  "slice_id": "SLICE-1",
+  "req_id": "REQ-1",
+  "title": "Initial slice",
+  "owner_role": "architect",
+  "status": "not_started",
+  "deliverables": {
+    "architect": {
+      "design_spec": "Updated architecture notes",
+      "evidence": [
+        {
+          "type": "file",
+          "ref": "docs/design.md",
+          "author": { "role": "architect", "id": "agent-3" }
+        }
+      ]
+    },
+    "coder": {
+      "implementation_notes": "Implemented parser changes",
+      "pr": "https://github.com/org/repo/pull/123",
+      "evidence": []
+    },
+    "tester": { "test_plan": null, "test_results": null, "evidence": [] }
+  }
+}
+```
+
+### PATCH /v1/slices/{slice_id}/tests
+Request:
+```json
+{
+  "test_plan": "Cover new endpoints",
+  "test_results": { "status": "pass", "notes": "All checks green." }
+}
+```
+
+Response (200):
+```json
+{
+  "slice_id": "SLICE-1",
+  "req_id": "REQ-1",
+  "title": "Initial slice",
+  "owner_role": "architect",
+  "status": "not_started",
+  "deliverables": {
+    "architect": {
+      "design_spec": "Updated architecture notes",
+      "evidence": [
+        {
+          "type": "file",
+          "ref": "docs/design.md",
+          "author": { "role": "architect", "id": "agent-3" }
+        }
+      ]
+    },
+    "coder": {
+      "implementation_notes": "Implemented parser changes",
+      "pr": "https://github.com/org/repo/pull/123",
+      "evidence": []
+    },
+    "tester": {
+      "test_plan": "Cover new endpoints",
+      "test_results": { "status": "pass", "notes": "All checks green." },
+      "evidence": []
+    }
+  }
+}
+```

--- a/src/routes/slices-v2.test.ts
+++ b/src/routes/slices-v2.test.ts
@@ -20,15 +20,24 @@ const coderHeaders = {
   "x-agent-id": "agent-2"
 };
 
+const architectHeaders = {
+  "x-agent-role": "architect",
+  "x-agent-id": "agent-3"
+};
+
+const testerHeaders = {
+  "x-agent-role": "tester",
+  "x-agent-id": "agent-4"
+};
+
 const defaultSliceResponse = {
   ...baseSlice,
   status: "not_started",
   deliverables: {
-    architect: { design_spec: null },
-    coder: { implementation_notes: null, pr: null },
-    tester: { test_plan: null, test_results: null }
-  },
-  evidence: []
+    architect: { design_spec: null, evidence: [] },
+    coder: { implementation_notes: null, pr: null, evidence: [] },
+    tester: { test_plan: null, test_results: null, evidence: [] }
+  }
 };
 
 beforeEach(async () => {
@@ -36,6 +45,13 @@ beforeEach(async () => {
 });
 
 describe("v2 slices endpoints", () => {
+  async function createSlice() {
+    await request(app)
+      .post("/v1/slices/bulk")
+      .set(pmHeaders)
+      .send({ slices: [baseSlice] });
+  }
+
   it("returns 401 when headers are missing on POST", async () => {
     const response = await request(app)
       .post("/v1/slices/bulk")
@@ -296,5 +312,253 @@ describe("v2 slices endpoints", () => {
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({ error: "not_found" });
+  });
+
+  it("returns 401 when headers are missing on PATCH endpoints", async () => {
+    const responses = await Promise.all([
+      request(app).patch("/v1/slices/SLICE-1/design").send({ design_spec: "Spec" }),
+      request(app)
+        .patch("/v1/slices/SLICE-1/implementation")
+        .send({ implementation_notes: "Notes" }),
+      request(app).patch("/v1/slices/SLICE-1/tests").send({ test_plan: "Plan" })
+    ]);
+
+    for (const response of responses) {
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "unauthorized" });
+    }
+  });
+
+  it("returns 401 for wrong role on PATCH endpoints", async () => {
+    await createSlice();
+
+    const responses = await Promise.all([
+      request(app)
+        .patch("/v1/slices/SLICE-1/design")
+        .set(coderHeaders)
+        .send({ design_spec: "Spec" }),
+      request(app)
+        .patch("/v1/slices/SLICE-1/implementation")
+        .set(testerHeaders)
+        .send({ implementation_notes: "Notes" }),
+      request(app)
+        .patch("/v1/slices/SLICE-1/tests")
+        .set(architectHeaders)
+        .send({ test_plan: "Plan" })
+    ]);
+
+    for (const response of responses) {
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "unauthorized" });
+    }
+  });
+
+  it("returns 404 when patching a missing slice", async () => {
+    const responses = await Promise.all([
+      request(app)
+        .patch("/v1/slices/SLICE-404/design")
+        .set(architectHeaders)
+        .send({ design_spec: "Spec" }),
+      request(app)
+        .patch("/v1/slices/SLICE-404/implementation")
+        .set(coderHeaders)
+        .send({ implementation_notes: "Notes" }),
+      request(app)
+        .patch("/v1/slices/SLICE-404/tests")
+        .set(testerHeaders)
+        .send({ test_plan: "Plan" })
+    ]);
+
+    for (const response of responses) {
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: "not_found" });
+    }
+  });
+
+  it("returns 400 for unknown fields in patch body", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/design")
+      .set(architectHeaders)
+      .send({ design_spec: "Spec", extra: "nope" });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
+  });
+
+  it("rejects cross-role fields in patch body", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/design")
+      .set(architectHeaders)
+      .send({ design_spec: "Spec", implementation_notes: "Notes" });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
+  });
+
+  it("does not erase other deliverables when patching different roles", async () => {
+    await createSlice();
+
+    const designResponse = await request(app)
+      .patch("/v1/slices/SLICE-1/design")
+      .set(architectHeaders)
+      .send({ design_spec: "Spec v1" });
+
+    expect(designResponse.status).toBe(200);
+    expect(designResponse.body.deliverables.architect.design_spec).toBe("Spec v1");
+
+    const implementationResponse = await request(app)
+      .patch("/v1/slices/SLICE-1/implementation")
+      .set(coderHeaders)
+      .send({ implementation_notes: "Notes v1" });
+
+    expect(implementationResponse.status).toBe(200);
+    expect(implementationResponse.body.deliverables.architect.design_spec).toBe("Spec v1");
+    expect(implementationResponse.body.deliverables.coder.implementation_notes).toBe("Notes v1");
+  });
+
+  it("appends evidence instead of replacing it", async () => {
+    await createSlice();
+
+    const firstResponse = await request(app)
+      .patch("/v1/slices/SLICE-1/design")
+      .set(architectHeaders)
+      .send({
+        design_spec: "Spec",
+        evidence: [{ type: "file", ref: "spec.md" }]
+      });
+
+    expect(firstResponse.status).toBe(200);
+    expect(firstResponse.body.deliverables.architect.evidence).toHaveLength(1);
+
+    const secondResponse = await request(app)
+      .patch("/v1/slices/SLICE-1/design")
+      .set(architectHeaders)
+      .send({
+        design_spec: "Spec v2",
+        evidence: [{ type: "command", ref: "make docs" }]
+      });
+
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.body.deliverables.architect.evidence).toHaveLength(2);
+  });
+
+  it("stores evidence only under the calling role", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/implementation")
+      .set(coderHeaders)
+      .send({
+        implementation_notes: "Notes",
+        evidence: [{ type: "pr", ref: "PR-123" }]
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.deliverables.coder.evidence).toHaveLength(1);
+    expect(response.body.deliverables.architect.evidence).toHaveLength(0);
+    expect(response.body.deliverables.tester.evidence).toHaveLength(0);
+  });
+
+  it("records evidence author info", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/tests")
+      .set(testerHeaders)
+      .send({
+        test_plan: "Plan",
+        evidence: [{ type: "test", ref: "Suite" }]
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.deliverables.tester.evidence).toHaveLength(1);
+    expect(response.body.deliverables.tester.evidence[0]).toMatchObject({
+      type: "test",
+      ref: "Suite",
+      author: { role: "tester", id: "agent-4" }
+    });
+    expect("result" in response.body.deliverables.tester.evidence[0]).toBe(false);
+  });
+
+  it("rejects status updates from patch requests", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/design")
+      .set(architectHeaders)
+      .send({ design_spec: "Spec", status: "in_progress" });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
+  });
+
+  it("rejects empty strings in patch payloads", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/implementation")
+      .set(coderHeaders)
+      .send({ implementation_notes: " " });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
+  });
+
+  it("rejects invalid evidence entries", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/tests")
+      .set(testerHeaders)
+      .send({
+        test_plan: "Plan",
+        evidence: [{ type: "artifact", ref: "file.txt", result: "pass" }]
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
+  });
+
+  it("rejects invalid evidence results", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/tests")
+      .set(testerHeaders)
+      .send({
+        test_plan: "Plan",
+        evidence: [{ type: "test", ref: "Suite", result: "maybe" }]
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
+  });
+
+  it("requires implementation_notes or pr in implementation patch", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/implementation")
+      .set(coderHeaders)
+      .send({ evidence: [{ type: "pr", ref: "PR-1" }] });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
+  });
+
+  it("requires test_plan or test_results in tests patch", async () => {
+    await createSlice();
+
+    const response = await request(app)
+      .patch("/v1/slices/SLICE-1/tests")
+      .set(testerHeaders)
+      .send({ evidence: [{ type: "test", ref: "Suite" }] });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_body" });
   });
 });

--- a/src/routes/slices-v2.ts
+++ b/src/routes/slices-v2.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
-import { bulkSlicesSchema } from "../validators/slices-v2.js";
+import {
+  bulkSlicesSchema,
+  designPatchSchema,
+  implementationPatchSchema,
+  testsPatchSchema
+} from "../validators/slices-v2.js";
 import { SliceV2 } from "../types/slices-v2.js";
-import { bulkCreateSlices, getSlice } from "../store/slices-store.js";
+import { bulkCreateSlices, getSlice, saveSlice } from "../store/slices-store.js";
 import { requireRole, requireV2Identity } from "../middleware/v2-auth.js";
 
 const router = Router();
@@ -22,11 +27,10 @@ router.post("/v1/slices/bulk", requireRole("pm"), async (req, res) => {
     status: "not_started",
     depends_on: item.depends_on,
     deliverables: {
-      architect: { design_spec: null },
-      coder: { implementation_notes: null, pr: null },
-      tester: { test_plan: null, test_results: null }
-    },
-    evidence: []
+      architect: { design_spec: null, evidence: [] },
+      coder: { implementation_notes: null, pr: null, evidence: [] },
+      tester: { test_plan: null, test_results: null, evidence: [] }
+    }
   }));
 
   const result = await bulkCreateSlices(slices);
@@ -48,6 +52,114 @@ router.get("/v1/slices/:slice_id", async (req, res) => {
     return res.status(404).json({ error: "not_found" });
   }
 
+  return res.status(200).json(slice);
+});
+
+router.patch("/v1/slices/:slice_id/design", requireRole("architect"), async (req, res) => {
+  const parsed = designPatchSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "invalid_body" });
+  }
+
+  const sliceId = String(req.params.slice_id || "").trim();
+  const slice = sliceId ? await getSlice(sliceId) : null;
+  if (!slice) {
+    return res.status(404).json({ error: "not_found" });
+  }
+
+  slice.deliverables.architect = {
+    ...slice.deliverables.architect,
+    design_spec: parsed.data.design_spec
+  };
+
+  if (parsed.data.evidence) {
+    const author = { role: req.agent!.role, id: req.agent!.id };
+    const existingEvidence = slice.deliverables.architect.evidence ?? [];
+    slice.deliverables.architect.evidence = [
+      ...existingEvidence,
+      ...parsed.data.evidence.map((entry) => ({ ...entry, author }))
+    ];
+  }
+
+  await saveSlice(slice);
+  return res.status(200).json(slice);
+});
+
+router.patch("/v1/slices/:slice_id/implementation", requireRole("coder"), async (req, res) => {
+  const parsed = implementationPatchSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "invalid_body" });
+  }
+
+  const sliceId = String(req.params.slice_id || "").trim();
+  const slice = sliceId ? await getSlice(sliceId) : null;
+  if (!slice) {
+    return res.status(404).json({ error: "not_found" });
+  }
+
+  if (parsed.data.implementation_notes) {
+    slice.deliverables.coder = {
+      ...slice.deliverables.coder,
+      implementation_notes: parsed.data.implementation_notes
+    };
+  }
+
+  if (parsed.data.pr) {
+    slice.deliverables.coder = {
+      ...slice.deliverables.coder,
+      pr: parsed.data.pr
+    };
+  }
+
+  if (parsed.data.evidence) {
+    const author = { role: req.agent!.role, id: req.agent!.id };
+    const existingEvidence = slice.deliverables.coder.evidence ?? [];
+    slice.deliverables.coder.evidence = [
+      ...existingEvidence,
+      ...parsed.data.evidence.map((entry) => ({ ...entry, author }))
+    ];
+  }
+
+  await saveSlice(slice);
+  return res.status(200).json(slice);
+});
+
+router.patch("/v1/slices/:slice_id/tests", requireRole("tester"), async (req, res) => {
+  const parsed = testsPatchSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "invalid_body" });
+  }
+
+  const sliceId = String(req.params.slice_id || "").trim();
+  const slice = sliceId ? await getSlice(sliceId) : null;
+  if (!slice) {
+    return res.status(404).json({ error: "not_found" });
+  }
+
+  if (parsed.data.test_plan) {
+    slice.deliverables.tester = {
+      ...slice.deliverables.tester,
+      test_plan: parsed.data.test_plan
+    };
+  }
+
+  if (parsed.data.test_results) {
+    slice.deliverables.tester = {
+      ...slice.deliverables.tester,
+      test_results: parsed.data.test_results
+    };
+  }
+
+  if (parsed.data.evidence) {
+    const author = { role: req.agent!.role, id: req.agent!.id };
+    const existingEvidence = slice.deliverables.tester.evidence ?? [];
+    slice.deliverables.tester.evidence = [
+      ...existingEvidence,
+      ...parsed.data.evidence.map((entry) => ({ ...entry, author }))
+    ];
+  }
+
+  await saveSlice(slice);
   return res.status(200).json(slice);
 });
 

--- a/src/store/slices-store.ts
+++ b/src/store/slices-store.ts
@@ -32,6 +32,12 @@ export async function getSlice(sliceId: string): Promise<SliceV2 | null> {
   }
 }
 
+export async function saveSlice(slice: SliceV2): Promise<void> {
+  const redis = await getRedisClient();
+  await redis.set(sliceKey(slice.slice_id), JSON.stringify(slice));
+  await redis.sAdd(SLICES_SET, slice.slice_id);
+}
+
 export async function bulkCreateSlices(
   items: SliceV2[]
 ): Promise<{ ok: true } | { ok: false; duplicates: string[] }> {

--- a/src/types/slices-v2.ts
+++ b/src/types/slices-v2.ts
@@ -1,9 +1,33 @@
 export type SliceOwnerRole = "pm" | "architect" | "coder" | "tester";
 
+export type SliceStatus = "not_started" | "in_progress" | "done" | "blocked";
+
+export type EvidenceType = "file" | "command" | "test" | "pr";
+export type EvidenceResult = "pass" | "fail";
+
+export interface EvidenceAuthor {
+  role: SliceOwnerRole;
+  id: string;
+}
+
+export interface EvidenceInput {
+  type: EvidenceType;
+  ref: string;
+  result?: EvidenceResult | null;
+}
+
 export interface SliceDeliverables {
-  architect: { design_spec: null };
-  coder: { implementation_notes: null; pr: null };
-  tester: { test_plan: null; test_results: null };
+  architect: { design_spec: string | null; evidence: Evidence[] };
+  coder: { implementation_notes: string | null; pr: string | null; evidence: Evidence[] };
+  tester: {
+    test_plan: string | null;
+    test_results: { status: string; notes?: string } | null;
+    evidence: Evidence[];
+  };
+}
+
+export interface Evidence extends EvidenceInput {
+  author: EvidenceAuthor;
 }
 
 export interface SliceV2 {
@@ -11,8 +35,7 @@ export interface SliceV2 {
   req_id: string;
   title: string;
   owner_role: SliceOwnerRole;
-  status: "not_started";
+  status: SliceStatus;
   depends_on?: string[];
   deliverables: SliceDeliverables;
-  evidence: [];
 }

--- a/src/validators/slices-v2.ts
+++ b/src/validators/slices-v2.ts
@@ -4,6 +4,14 @@ const nonEmptyString = z.string().trim().min(1);
 
 export const sliceOwnerRoleSchema = z.enum(["pm", "architect", "coder", "tester"]);
 
+export const evidenceSchema = z
+  .object({
+    type: z.enum(["file", "command", "test", "pr"]),
+    ref: nonEmptyString,
+    result: z.enum(["pass", "fail"]).nullable().optional()
+  })
+  .strict();
+
 export const sliceInputSchema = z
   .object({
     slice_id: nonEmptyString,
@@ -19,3 +27,49 @@ export const bulkSlicesSchema = z
     slices: z.array(sliceInputSchema)
   })
   .strict();
+
+export const designPatchSchema = z
+  .object({
+    design_spec: nonEmptyString,
+    evidence: z.array(evidenceSchema).optional()
+  })
+  .strict();
+
+export const implementationPatchSchema = z
+  .object({
+    implementation_notes: nonEmptyString.optional(),
+    pr: nonEmptyString.optional(),
+    evidence: z.array(evidenceSchema).optional()
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (!value.implementation_notes && !value.pr) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "implementation_notes or pr is required"
+      });
+    }
+  });
+
+export const testResultsSchema = z
+  .object({
+    status: nonEmptyString,
+    notes: nonEmptyString.optional()
+  })
+  .strict();
+
+export const testsPatchSchema = z
+  .object({
+    test_plan: nonEmptyString.optional(),
+    test_results: testResultsSchema.optional(),
+    evidence: z.array(evidenceSchema).optional()
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (!value.test_plan && !value.test_results) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "test_plan or test_results is required"
+      });
+    }
+  });


### PR DESCRIPTION
### Motivation
- Prevent role-scoped PATCH endpoints from changing global slice `status` so `status` remains PM-owned only. 
- Scope evidence to the caller's deliverables subtree and record an `author` footprint for provenance. 
- Enforce strict per-endpoint allowlists so roles can only write their own fields and unknown/cross-role fields are rejected. 
- Make evidence append-only and validate evidence and test result shapes consistently.

### Description
- Added role-scoped patch routes in `src/routes/slices-v2.ts` (`PATCH /v1/slices/{slice_id}/design`, `/implementation`, `/tests`) that apply changes only to the caller's deliverables subtree, append evidence with an `author`, and reject `status` in role requests. 
- Introduced `saveSlice` in `src/store/slices-store.ts` and updated callers to persist modified slices. 
- Enhanced types in `src/types/slices-v2.ts` to model `Evidence`, `EvidenceAuthor`, and the new deliverables shape, and replaced the inline `status` literal with `SliceStatus`. 
- Tightened validation in `src/validators/slices-v2.ts` with `.strict()` schemas for each role patch, an `evidenceSchema`, and `superRefine` rules to require role-specific fields; updated tests in `src/routes/slices-v2.test.ts` to exercise auth, allowlists, evidence scoping/append semantics, and rejection of `status`. 
- Updated `PR3_REVIEW.md` to explicitly document that role PATCH endpoints reject `status` (400), include short per-endpoint payload allowlists, and clarify that `test_results.status` is distinct from `evidence.result`.

### Testing
- Added integration tests in `src/routes/slices-v2.test.ts` that cover header-based auth, wrong-role rejection, unknown/cross-role field rejection, evidence append-only behavior, evidence author metadata, and rejection of `status` in role PATCHes. 
- Attempted to run the test suite with `npm test` (Vitest) but the run was aborted due to Redis being unavailable (`ECONNREFUSED 127.0.0.1:6379`). 
- The new tests exercise the intended behaviors (reject `status`, scope evidence to the role, enforce allowlists) but could not complete in CI due to the Redis failure. 
- The final documentation-only edit to `PR3_REVIEW.md` was committed and not executed as part of tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c97bd69c83259962f4a57a358228)