### PR TITLE
Add GET /v1/run/next endpoint (PR8)

### DIFF
--- a/PR8_REVIEW.md
+++ b/PR8_REVIEW.md
@@ -1,0 +1,37 @@
+# PR8 Review Notes
+
+## Endpoint
+- `GET /v1/run/next?role=architect|coder|tester`
+- Auth: v2 headers required
+
+## Query Parameters
+- `role` is required.
+- Invalid roles (including `pm`) return `400 { "error": "invalid_role" }`.
+
+## Response
+```json
+{
+  "slice_id": "SLICE-1",
+  "view": {
+    "slice": {
+      "slice_id": "SLICE-1",
+      "req_id": "REQ-1",
+      "title": "Title",
+      "owner_role": "architect",
+      "status": "not_started",
+      "depends_on": [],
+      "claimed_by": null,
+      "claimed_at": null,
+      "deliverables": {
+        "architect": { "design_spec": "Spec" }
+      }
+    }
+  }
+}
+```
+
+## Behavior
+- Uses the same next-slice selection logic as `GET /v1/slices/next`.
+- Returns `404 { "error": "not_found" }` when no eligible slice exists.
+- Does not claim or update slices.
+- Returns the view payload based on the caller role (same as `GET /v1/views/slice/{slice_id}`).

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import path from "path";
 import { appendFile, mkdir, readFile } from "fs/promises";
 import requirementsV2Router from "./routes/requirements-v2.js";
+import runV2Router from "./routes/run-v2.js";
 import slicesV2Router from "./routes/slices-v2.js";
 import viewsV2Router from "./routes/views-v2.js";
 
@@ -72,6 +73,7 @@ app.get("/prompt/:name", async (req, res) => {
   }
 });
 app.use(requirementsV2Router);
+app.use(runV2Router);
 app.use(slicesV2Router);
 app.use(viewsV2Router);
 

--- a/src/routes/run-v2.test.ts
+++ b/src/routes/run-v2.test.ts
@@ -1,0 +1,187 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../app.js";
+import { clearSlicesStore } from "../store/slices-store.js";
+
+const baseSlice = {
+  slice_id: "SLICE-RUN-1",
+  req_id: "REQ-1",
+  title: "Run next",
+  owner_role: "architect",
+  depends_on: []
+};
+
+const pmHeaders = {
+  "x-agent-role": "pm",
+  "x-agent-id": "agent-1"
+};
+
+const architectHeaders = {
+  "x-agent-role": "architect",
+  "x-agent-id": "agent-2"
+};
+
+const coderHeaders = {
+  "x-agent-role": "coder",
+  "x-agent-id": "agent-3"
+};
+
+const testerHeaders = {
+  "x-agent-role": "tester",
+  "x-agent-id": "agent-4"
+};
+
+beforeEach(async () => {
+  await clearSlicesStore();
+});
+
+describe("v2 run next", () => {
+  async function createSliceWithDeliverables() {
+    await request(app).post("/v1/slices/bulk").set(pmHeaders).send({ slices: [baseSlice] });
+
+    await request(app)
+      .patch(`/v1/slices/${baseSlice.slice_id}/design`)
+      .set(architectHeaders)
+      .send({
+        design_spec: "Spec",
+        evidence: [{ type: "file", ref: "spec.md" }]
+      });
+
+    await request(app)
+      .patch(`/v1/slices/${baseSlice.slice_id}/implementation`)
+      .set(coderHeaders)
+      .send({
+        implementation_notes: "Notes",
+        pr: "PR-1",
+        evidence: [{ type: "pr", ref: "PR-1" }]
+      });
+
+    await request(app)
+      .patch(`/v1/slices/${baseSlice.slice_id}/tests`)
+      .set(testerHeaders)
+      .send({
+        test_plan: "Plan",
+        test_results: { status: "pass", notes: "ok" },
+        evidence: [{ type: "test", ref: "Suite" }]
+      });
+  }
+
+  it("returns 401 when headers are missing", async () => {
+    const response = await request(app).get("/v1/run/next").query({ role: "architect" });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ error: "unauthorized" });
+  });
+
+  it("returns 400 for invalid role", async () => {
+    const response = await request(app)
+      .get("/v1/run/next")
+      .set(pmHeaders)
+      .query({ role: "pm" });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "invalid_role" });
+  });
+
+  it("returns 404 when no eligible slices exist", async () => {
+    const response = await request(app)
+      .get("/v1/run/next")
+      .set(coderHeaders)
+      .query({ role: "coder" });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: "not_found" });
+  });
+
+  it("returns next slice with architect view", async () => {
+    await createSliceWithDeliverables();
+
+    const response = await request(app)
+      .get("/v1/run/next")
+      .set(architectHeaders)
+      .query({ role: "architect" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.slice_id).toBe(baseSlice.slice_id);
+    expect(response.body.view.slice).toMatchObject({
+      slice_id: baseSlice.slice_id,
+      req_id: baseSlice.req_id,
+      title: baseSlice.title,
+      owner_role: baseSlice.owner_role,
+      status: "not_started",
+      depends_on: baseSlice.depends_on,
+      claimed_by: null,
+      claimed_at: null,
+      deliverables: {
+        architect: { design_spec: "Spec" }
+      }
+    });
+    expect(response.body.view.slice).not.toHaveProperty("evidence");
+    expect(response.body.view.slice.deliverables).not.toHaveProperty("coder");
+    expect(response.body.view.slice.deliverables).not.toHaveProperty("tester");
+  });
+
+  it("returns next slice with coder view", async () => {
+    await createSliceWithDeliverables();
+
+    const response = await request(app)
+      .get("/v1/run/next")
+      .set(coderHeaders)
+      .query({ role: "architect" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.slice_id).toBe(baseSlice.slice_id);
+    expect(response.body.view.slice.deliverables).toMatchObject({
+      architect: { design_spec: "Spec" },
+      coder: { implementation_notes: "Notes", pr: "PR-1" }
+    });
+    expect(response.body.view.slice).not.toHaveProperty("evidence");
+    expect(response.body.view.slice.deliverables).not.toHaveProperty("tester");
+  });
+
+  it("returns next slice with tester view", async () => {
+    await createSliceWithDeliverables();
+
+    const response = await request(app)
+      .get("/v1/run/next")
+      .set(testerHeaders)
+      .query({ role: "architect" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.slice_id).toBe(baseSlice.slice_id);
+    expect(response.body.view.slice.deliverables).toMatchObject({
+      architect: { design_spec: "Spec" },
+      coder: { implementation_notes: "Notes", pr: "PR-1" },
+      tester: { test_plan: "Plan", test_results: { status: "pass", notes: "ok" } }
+    });
+    expect(response.body.view.slice).not.toHaveProperty("evidence");
+  });
+
+  it("returns next slice with pm view", async () => {
+    await createSliceWithDeliverables();
+
+    const response = await request(app)
+      .get("/v1/run/next")
+      .set(pmHeaders)
+      .query({ role: "architect" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.slice_id).toBe(baseSlice.slice_id);
+    expect(response.body.view.slice.deliverables.architect).toMatchObject({
+      design_spec: "Spec"
+    });
+    expect(response.body.view.slice.deliverables.coder).toMatchObject({
+      implementation_notes: "Notes",
+      pr: "PR-1"
+    });
+    expect(response.body.view.slice.deliverables.tester).toMatchObject({
+      test_plan: "Plan",
+      test_results: { status: "pass", notes: "ok" }
+    });
+    expect(response.body.view.slice.evidence).toEqual([
+      { type: "file", ref: "spec.md" },
+      { type: "pr", ref: "PR-1" },
+      { type: "test", ref: "Suite" }
+    ]);
+  });
+});

--- a/src/routes/run-v2.ts
+++ b/src/routes/run-v2.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import { requireV2Identity } from "../middleware/v2-auth.js";
+import { findNextSlice } from "../store/next-slice.js";
+import { SliceOwnerRole } from "../types/slices-v2.js";
+import { nextSliceRoleSchema } from "../validators/slices-v2.js";
+import { buildSliceView } from "../views/slice-view.js";
+
+const router = Router();
+
+router.use(requireV2Identity);
+
+router.get("/v1/run/next", async (req, res) => {
+  const roleInput = typeof req.query.role === "string" ? req.query.role : "";
+  const parsedRole = nextSliceRoleSchema.safeParse(roleInput);
+  if (!parsedRole.success) {
+    return res.status(400).json({ error: "invalid_role" });
+  }
+
+  const nextSlice = await findNextSlice(parsedRole.data);
+  if (!nextSlice) {
+    return res.status(404).json({ error: "not_found" });
+  }
+
+  const callerRole = req.agent!.role as SliceOwnerRole;
+  return res.status(200).json({
+    slice_id: nextSlice.slice_id,
+    view: buildSliceView(nextSlice, callerRole)
+  });
+});
+
+export default router;

--- a/src/routes/slices-v2.ts
+++ b/src/routes/slices-v2.ts
@@ -12,10 +12,10 @@ import { SliceV2 } from "../types/slices-v2.js";
 import {
   bulkCreateSlices,
   getSlice,
-  listSlicesInOrder,
   saveSlice
 } from "../store/slices-store.js";
 import { requireRole, requireV2Identity } from "../middleware/v2-auth.js";
+import { findNextSlice } from "../store/next-slice.js";
 
 const router = Router();
 
@@ -62,34 +62,7 @@ router.get("/v1/slices/next", async (req, res) => {
     return res.status(400).json({ error: "invalid_role" });
   }
 
-  const slices = await listSlicesInOrder();
-  if (slices.length === 0) {
-    return res.status(404).json({ error: "not_found" });
-  }
-
-  const sliceMap = new Map(slices.map((slice) => [slice.slice_id, slice]));
-  const nextSlice = slices.find((slice) => {
-    if (slice.owner_role !== parsedRole.data) {
-      return false;
-    }
-    if (slice.claimed_by) {
-      return false;
-    }
-    if (slice.status === "done") {
-      return false;
-    }
-    if (slice.depends_on && slice.depends_on.length > 0) {
-      const dependenciesReady = slice.depends_on.every((dependency) => {
-        const dependencySlice = sliceMap.get(dependency);
-        return dependencySlice?.status === "done";
-      });
-      if (!dependenciesReady) {
-        return false;
-      }
-    }
-    return true;
-  });
-
+  const nextSlice = await findNextSlice(parsedRole.data);
   if (!nextSlice) {
     return res.status(404).json({ error: "not_found" });
   }

--- a/src/store/next-slice.ts
+++ b/src/store/next-slice.ts
@@ -1,0 +1,34 @@
+import { NextSliceRole, SliceV2 } from "../types/slices-v2.js";
+import { listSlicesInOrder } from "./slices-store.js";
+
+export async function findNextSlice(role: NextSliceRole): Promise<SliceV2 | null> {
+  const slices = await listSlicesInOrder();
+  if (slices.length === 0) {
+    return null;
+  }
+
+  const sliceMap = new Map(slices.map((slice) => [slice.slice_id, slice]));
+  return (
+    slices.find((slice) => {
+      if (slice.owner_role !== role) {
+        return false;
+      }
+      if (slice.claimed_by) {
+        return false;
+      }
+      if (slice.status === "done") {
+        return false;
+      }
+      if (slice.depends_on && slice.depends_on.length > 0) {
+        const dependenciesReady = slice.depends_on.every((dependency) => {
+          const dependencySlice = sliceMap.get(dependency);
+          return dependencySlice?.status === "done";
+        });
+        if (!dependenciesReady) {
+          return false;
+        }
+      }
+      return true;
+    }) ?? null
+  );
+}

--- a/src/types/slices-v2.ts
+++ b/src/types/slices-v2.ts
@@ -1,4 +1,5 @@
 export type SliceOwnerRole = "pm" | "architect" | "coder" | "tester";
+export type NextSliceRole = Exclude<SliceOwnerRole, "pm">;
 
 export type SliceStatus = "not_started" | "in_progress" | "done" | "blocked";
 


### PR DESCRIPTION
### Motivation
- Implement the PR8 portion of `ORCHESTRATION_SPEC_v2.md` to provide a helper endpoint that composes the next eligible slice selection and the caller-specific view.
- Reuse existing next-slice selection logic without duplicating it, and ensure the helper does not claim or modify slices.
- Enforce `v2` identity requirements and validate the `role` query parameter to prevent invalid or PM roles from being used.
- Preserve view redaction rules so non-PM callers do not receive global state or evidence they shouldn't see.

### Description
- Added `src/store/next-slice.ts` which exports `findNextSlice` to encapsulate the next-slice selection logic used by other routes. 
- Added `src/routes/run-v2.ts` which implements `GET /v1/run/next?role=architect|coder|tester`, requires `v2` auth, validates `role`, uses `findNextSlice`, and returns `{ "slice_id": "...", "view": <view> }` without claiming slices. 
- Rewired `src/app.ts` to mount the new router and refactored `src/routes/slices-v2.ts` to call `findNextSlice` instead of inlining selection logic. 
- Added tests `src/routes/run-v2.test.ts` covering header auth, invalid role, not-found, and successful responses for each caller role, and added `PR8_REVIEW.md` documenting the endpoint and response shape.

### Testing
- Added unit tests in `src/routes/run-v2.test.ts` that cover `401` missing headers, `400` invalid role, `404` when no eligible slice exists, and `200` responses with the expected `slice_id` and role-specific `view` payloads (tests present but not all executed due to environment). 
- Ran the test suite with `npm test`, which attempted to run Vitest but failed due to a Redis connection error (`ECONNREFUSED 127.0.0.1:6379`). 
- No further automated test failures in code logic were observed locally because tests could not complete without a running Redis instance. 
- Manual inspection confirms that the new endpoint reuses `findNextSlice` and `buildSliceView` so selection and redaction logic remain centralized and consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69524ebf84088325805c72ef58559043)